### PR TITLE
Add ability to auth based on tls.Config

### DIFF
--- a/v2/network/connect_option.go
+++ b/v2/network/connect_option.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -75,6 +76,7 @@ type ConnectionOption struct {
 	Failover     int
 	RetryTime    int
 	Lob          int
+	TLSConfig    *tls.Config
 }
 
 func extractServers(connStr string) ([]ServerAddr, error) {

--- a/v2/network/session.go
+++ b/v2/network/session.go
@@ -257,13 +257,20 @@ func (session *Session) LoadSSLData(certs, keys, certRequests [][]byte) error {
 // used to create sslConn object
 func (session *Session) negotiate() {
 	connOption := session.Context.ConnOption
+	host := connOption.GetActiveServer(false)
+
+	if tlsConfig := session.Context.ConnOption.TLSConfig; tlsConfig != nil {
+		tlsConfig.ServerName = host.Addr
+		session.sslConn = tls.Client(session.conn, tlsConfig)
+		return
+	}
+
 	if session.SSL.roots == nil && len(session.SSL.Certificates) > 0 {
 		session.SSL.roots = x509.NewCertPool()
 		for _, cert := range session.SSL.Certificates {
 			session.SSL.roots.AddCert(cert)
 		}
 	}
-	host := connOption.GetActiveServer(false)
 	config := &tls.Config{
 		ServerName: host.Addr,
 	}
@@ -275,12 +282,6 @@ func (session *Session) negotiate() {
 	}
 	if !connOption.SSLVerify {
 		config.InsecureSkipVerify = true
-	}
-
-	if tlsConfig := session.Context.ConnOption.TLSConfig; tlsConfig != nil {
-		tlsConfig.ServerName = host.Addr
-		session.sslConn = tls.Client(session.conn, tlsConfig)
-		return
 	}
 
 	session.sslConn = tls.Client(session.conn, config)
@@ -445,7 +446,7 @@ func (session *Session) Connect(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if connOption.SSL || connOption.TLSConfig != nil {
+	if connOption.SSL {
 		connOption.Tracer.Print("Using SSL/TLS")
 		session.negotiate()
 	}


### PR DESCRIPTION
### What
Add ability to preform x509 auth based on tls.Config. Currently CN auth can be done only based on Oracle Wallet file. 